### PR TITLE
Update Formiko runtime to 46

### DIFF
--- a/cz.zeropage.Formiko.json
+++ b/cz.zeropage.Formiko.json
@@ -1,7 +1,7 @@
 {
     "app-id": "cz.zeropage.Formiko",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "formiko",
     "rename-icon": "formiko",

--- a/cz.zeropage.Formiko.json
+++ b/cz.zeropage.Formiko.json
@@ -73,6 +73,10 @@
                 {
                     "type": "patch",
                     "path": "Allow-webkitgtk-4.1.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_appdata.patch"
                 }
             ]
         }

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,74 @@
+From d4f4f31cddb4c28d3fa614e2bb7d527abe2203a4 Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Fri, 7 Jun 2024 23:07:17 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ formiko.metainfo.xml | 35 +++++++++++------------------------
+ 1 file changed, 11 insertions(+), 24 deletions(-)
+
+diff --git a/formiko.metainfo.xml b/formiko.metainfo.xml
+index e1cfef8..7021d39 100644
+--- a/formiko.metainfo.xml
++++ b/formiko.metainfo.xml
+@@ -4,29 +4,15 @@
+     <name>Formiko</name>
+     <summary>reStructuredText and MarkDown editor and live previewer</summary>
+     <!-- Copyright 2018 Ondřej Tůma -->
+-    <keywords>
+-        <keyword>Documentation</keyword>
+-        <keyword>Markup</keyword>
+-        <keyword>Editor</keyword>
+-        <keywords>Text</keywords>
+-        <keywords>MarkDown</keywords>
+-        <keywords>reStructuredText</keywords>
+-    </keywords>
+-    <categories>
+-        <category>Office</category>
+-        <category>WordProcessor</category>
+-        <category>GNOME</category>
+-        <category>GTK</category>
+-    </categories>
+-    <mimetypes>
+-        <mimetype>text/plain</mimetype>
+-        <mimetype>text/html</mimetype>
+-        <mimetype>text/x-mardown</mimetype>
+-        <mimetype>text/x-rst</mimetype>
+-        <mimetype>application/json</mimetype>
+-        <mimetype>text/json</mimetype>
+-    </mimetypes>
+-    <content_rating type="oars-1.0"/>
++    <provides>
++        <mediatype>text/plain</mediatype>
++        <mediatype>text/html</mediatype>
++        <mediatype>text/x-mardown</mediatype>
++        <mediatype>text/x-rst</mediatype>
++        <mediatype>application/json</mediatype>
++        <mediatype>text/json</mediatype>
++    </provides>
++    <content_rating type="oars-1.1"/>
+     <releases>
+         <release version="1.4.2" type="stable" date="2019-12-02">
+             <url>https://github.com/ondratu/formiko/releases/tag/1.4.2</url>
+@@ -37,15 +23,16 @@
+     </releases>
+     <url type="homepage">https://github.com/ondratu/formiko</url>
+     <url type="bugtracker">https://github.com/ondratu/formiko/issues</url>
++    <url type="vcs-browser">https://github.com/ondratu/formiko</url>
+     <launchable type="desktop-id">cz.zeropage.Formiko.desktop</launchable>
+     <metadata_license>MIT</metadata_license>
+     <project_license>BSD-3-Clause</project_license>
+     <description>
+         <p>Formiko is reStructuredText and MarkDown editor and live previewer.
+         It is written in Python with Gtk3, GtkSourceView and Webkit2. Use
+         Docutils and recommonmark Common Mark parser.</p>
+ 
+-        Features:
++        <p>Features:</p>
+         <ul>
+             <li>GtkSourceView based editor with syntax highlighting</li>
+             <li>Possible use Vim editor</li>
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- Update Formiko runtime to 46 since runtime version 44 has reached end-of-life.
- Fix appdata papercuts